### PR TITLE
Remoção de espaço no arquivo paginate_helper que causa espaçamento no topo da aplicação

### DIFF
--- a/your_app_name/vendor/plugins/drumon_model/helpers/paginate_helper.php
+++ b/your_app_name/vendor/plugins/drumon_model/helpers/paginate_helper.php
@@ -303,10 +303,8 @@ class PaginateHelper extends Helper {
 		return substr($s1, 0, strpos($s1, $s2));
 	}
 }
-?>
 
 
-<?php
 /**
  * Query String Management Class
  *


### PR DESCRIPTION
Remoção de espaço no arquivo paginate_helper que causa espaçamento no topo da aplicação

Para geração de arquivos RSS estava dando erro com esse espaço. (BY Bruno Serrão @bornslip)
